### PR TITLE
Debug slack oauth credential loss on refresh

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,6 +31,7 @@ const AppContent: React.FC = () => {
         }
 
         if (workspaceId && teamName) {
+          console.log('OAuth callback detected, processing authentication...');
           // OAuth success - handle new authentication
           try {
             // Try to fetch user info to verify the authentication
@@ -49,8 +50,9 @@ const AppContent: React.FC = () => {
                 user
               };
               setAuth(newAuth);
-              console.log('OAuth authentication successful');
+              console.log('OAuth authentication successful with user data');
             } else {
+              console.warn('OAuth successful but failed to fetch user info, proceeding with basic auth');
               // If user info fetch fails, still set basic auth state
               const newAuth = {
                 isAuthenticated: true,
@@ -59,7 +61,6 @@ const AppContent: React.FC = () => {
                 user: null
               };
               setAuth(newAuth);
-              console.warn('OAuth successful but failed to fetch user info');
             }
           } catch (error) {
             console.error('Failed to complete OAuth authentication:', error);
@@ -77,14 +78,14 @@ const AppContent: React.FC = () => {
           window.history.replaceState({}, document.title, window.location.pathname);
         } else {
           // No OAuth parameters, try to restore existing authentication
-          console.log('No OAuth parameters, attempting to restore authentication');
+          console.log('No OAuth parameters, attempting to restore authentication from storage...');
           const restoredAuth = await restoreAuth();
           
           if (restoredAuth.isAuthenticated) {
-            console.log('Authentication restored successfully');
+            console.log('Authentication restored successfully from storage');
             setAuth(restoredAuth);
           } else {
-            console.log('No valid authentication found');
+            console.log('No valid authentication found in storage');
           }
         }
       } catch (error) {

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -2,13 +2,15 @@ import React, { useState } from 'react';
 import MessageComposer from '../components/MessageComposer';
 import ScheduledMessages from '../components/ScheduledMessages';
 import NewMessageModal from '../components/NewMessageModal';
-import { MessageSquare, Calendar, BarChart3, Plus, Clock, CheckCircle2 } from 'lucide-react';
+import { useAppContext } from '../contexts/AppContext';
+import { MessageSquare, Calendar, BarChart3, Plus, Clock, CheckCircle2, Bug } from 'lucide-react';
 
 type TabType = 'compose' | 'scheduled' | 'analytics';
 
 const DashboardPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<TabType>('compose');
   const [isNewMessageModalOpen, setIsNewMessageModalOpen] = useState(false);
+  const { debugAuthState } = useAppContext();
 
   const tabs = [
     {
@@ -116,13 +118,25 @@ const DashboardPage: React.FC = () => {
             </div>
             
             {/* Quick Action Button */}
-            <button 
-              onClick={() => setIsNewMessageModalOpen(true)}
-              className="btn-primary flex items-center space-x-2 lg:w-auto w-full justify-center group"
-            >
-              <Plus className="w-5 h-5 group-hover:scale-110 transition-transform duration-200" />
-              <span>New Message</span>
-            </button>
+            <div className="flex gap-3 lg:w-auto w-full justify-center">
+              <button 
+                onClick={() => setIsNewMessageModalOpen(true)}
+                className="btn-primary flex items-center space-x-2 group"
+              >
+                <Plus className="w-5 h-5 group-hover:scale-110 transition-transform duration-200" />
+                <span>New Message</span>
+              </button>
+              
+              {/* Debug Button - Remove in production */}
+              <button 
+                onClick={debugAuthState}
+                className="btn-secondary flex items-center space-x-2 group"
+                title="Debug Authentication State"
+              >
+                <Bug className="w-5 h-5 group-hover:scale-110 transition-transform duration-200" />
+                <span className="hidden sm:inline">Debug</span>
+              </button>
+            </div>
           </div>
         </div>
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,6 +1,14 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
 import { SlackChannel, ScheduledMessage, User } from '../types';
 
+// Auth storage keys - keep in sync with AppContext
+const AUTH_STORAGE_KEYS = {
+  WORKSPACE_ID: 'slack_workspace_id',
+  TEAM_NAME: 'slack_team_name',
+  AUTH_TIMESTAMP: 'slack_auth_timestamp',
+  USER_DATA: 'slack_user_data'
+} as const;
+
 class ApiService {
   private api: AxiosInstance;
   private isRefreshing = false;
@@ -20,7 +28,7 @@ class ApiService {
 
     // Add request interceptor to include workspace ID
     this.api.interceptors.request.use((config) => {
-      const workspaceId = localStorage.getItem('slack_workspace_id');
+      const workspaceId = localStorage.getItem(AUTH_STORAGE_KEYS.WORKSPACE_ID);
       if (workspaceId) {
         config.headers['x-workspace-id'] = workspaceId;
       }
@@ -50,7 +58,7 @@ class ApiService {
           this.isRefreshing = true;
 
           try {
-            const workspaceId = localStorage.getItem('slack_workspace_id');
+            const workspaceId = localStorage.getItem(AUTH_STORAGE_KEYS.WORKSPACE_ID);
             if (!workspaceId) {
               throw new Error('No workspace ID found');
             }
@@ -127,10 +135,10 @@ class ApiService {
   private clearAuthAndRedirect(): void {
     // Clear authentication storage
     const authKeys = [
-      'slack_workspace_id',
-      'slack_team_name',
-      'slack_auth_timestamp',
-      'slack_user_data'
+      AUTH_STORAGE_KEYS.WORKSPACE_ID,
+      AUTH_STORAGE_KEYS.TEAM_NAME,
+      AUTH_STORAGE_KEYS.AUTH_TIMESTAMP,
+      AUTH_STORAGE_KEYS.USER_DATA
     ];
     authKeys.forEach(key => localStorage.removeItem(key));
     

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -31,6 +31,7 @@ export interface AuthState {
   workspaceId: string | null;
   teamName: string | null;
   user: User | null;
+  timestamp?: string | null; // Optional timestamp for fallback logic
 }
 
 export interface AppContextType {
@@ -40,4 +41,5 @@ export interface AppContextType {
   restoreAuth: () => Promise<AuthState>;
   verifyAuth: (workspaceId: string) => Promise<boolean>;
   getStoredAuth: () => Partial<AuthState> | null;
+  debugAuthState: () => void;
 }


### PR DESCRIPTION
Improve client-side OAuth authentication persistence and reliability on page refresh.

This PR fixes credentials being lost on refresh due to race conditions, inconsistent storage key usage, and a lack of a fallback mechanism when server verification fails. It ensures users remain logged in by implementing a robust authentication restoration process, including a fallback to recent stored data, and adds debugging tools for easier troubleshooting.

---
<a href="https://cursor.com/background-agent?bcId=bc-25d4b6d6-7a0b-48dc-9a28-68a9d42ca0db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25d4b6d6-7a0b-48dc-9a28-68a9d42ca0db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

